### PR TITLE
avoiding incompatible dtype error

### DIFF
--- a/name_matching/name_matcher.py
+++ b/name_matching/name_matcher.py
@@ -371,7 +371,7 @@ class NameMatcher:
 
         indexes = np.array([[f'match_name_{num}', f'score_{num}', f'match_index_{num}']
                             for num in range(self._number_of_matches)]).flatten()
-        match = pd.Series(index=np.append('original_name', indexes), dtype=float)
+        match = pd.Series(index=np.append('original_name', indexes), dtype=object)
         match['original_name'] = to_be_matched[self._column_matching]
         list_possible_matches = self._df_matching_data.iloc[
             possible_matches.flatten(), :][self._column].values


### PR DESCRIPTION
The only change just changes a Series dtype from float64 to object. This Series is populated by NaN by default, which Pandas reads as a float. That's fine until the names inserted into the series are strings, which is an incompatible dtype. This doesn't change functionality, but should remove that warning (and error, whenever Pandas drops support for it).