### PR TITLE
.flatten() error fix

### DIFF
--- a/name_matching/name_matcher.py
+++ b/name_matching/name_matcher.py
@@ -1019,7 +1019,7 @@ class NameMatcher:
             vectoriser is initialised
             default: True
         """
-        self._vec.fit(self._df_matching_data[self._column].values.flatten().astype(str))  # type: ignore
+        self._vec.fit(self._df_matching_data[self._column].to_numpy())  # type: ignore
         if transform:
             self.transform_data()
 


### PR DESCRIPTION
Used this library after ~2 years and was unable to run the basic examples from the docs, consistently encountering the following error:



```
Traceback (most recent call last):
  File "/Users//Desktop/hacktoberfest2025/name_matching/check.py", line 48, in <module>
    matcher.load_and_process_master_data(column='Company name',
  File "/Users//Desktop/hacktoberfest2025/name_matching/name_matching/name_matcher.py", line 601, in load_and_process_master_data
    self._process_matching_data(transform)
  File "/Users//Desktop/hacktoberfest2025/name_matching/name_matching/name_matcher.py", line 641, in _process_matching_data
    self._vectorise_data(transform)
  File "/Users//Desktop/hacktoberfest2025/name_matching/name_matching/name_matcher.py", line 1022, in _vectorise_data
    self._vec.fit(self._df_matching_data[self._column].values.flatten().astype(str))  # type: ignore
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'StringArray' object has no attribute 'flatten'
```

### Root Cause

The issue arises due to changes in pandas (>= 1.0, more prominent in 2.x):

-Series.values no longer reliably returns a NumPy array
-For string dtype columns, it returns a StringArray
-StringArray does not support flatten(), causing the failure

The current implementation assumes:

.values → numpy.ndarray

which is no longer always true.

###  Fix Implemented

Replaced:
`self._df_matching_data[self._column].values.flatten().astype(str)`

With:
`self._df_matching_data[self._column].to_numpy()
`

### Current output
Now the example runs well:
```

preprocessing...

preprocessing complete 
 searching for matches...

100%|█████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 1125.99it/s]
possible matches found   
 fuzzy matching...

100%|█████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:01<00:00,  6.46it/s]
done
```